### PR TITLE
changes the order of calls when mining in accurate/silk touch mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683056771
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,10 +69,10 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
-print("You might want to check out './gradlew :faq' if your build fails.")
+print("You might want to check out './gradlew :faq' if your build fails.\n")
 
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -222,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -567,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -727,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -819,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 
@@ -1264,7 +1279,9 @@ tasks.register('faq') {
         print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
             "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
             "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.")
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.09:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev')
     implementation('curse.maven:cofh-lib-220333:2388748')
     implementation(deobf('https://forum.industrial-craft.net/core/attachment/4519-gravisuite-1-7-10-2-0-3-jar'))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
@@ -67,7 +67,8 @@ public class MixinItemVajra {
                     value = "INVOKE",
                     ordinal = 0,
                     target = "Lnet/minecraft/block/Block;onBlockHarvested(Lnet/minecraft/world/World;IIIILnet/minecraft/entity/player/EntityPlayer;)V"))
-    private void gravisuiteneo$onBlockHarvestToNoOp(Block block, World world, int x, int y, int z, int meta, EntityPlayer player) {
+    private void gravisuiteneo$onBlockHarvestToNoOp(Block block, World world, int x, int y, int z, int meta,
+            EntityPlayer player) {
         return;
     }
 
@@ -84,7 +85,8 @@ public class MixinItemVajra {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/block/Block;harvestBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIII)V"))
-    private void gravisuiteneo$fixCallOrder(Block block, World world, EntityPlayer player, int x, int y, int z, int meta) {
+    private void gravisuiteneo$fixCallOrder(Block block, World world, EntityPlayer player, int x, int y, int z,
+            int meta) {
         block.onBlockHarvested(world, x, y, z, meta, player);
         world.setBlockToAir(x, y, z);
         block.harvestBlock(world, player, x, y, z, meta);
@@ -95,12 +97,9 @@ public class MixinItemVajra {
     // dropFlag = true
     @Inject(
             method = "onItemUse",
-            at = @At(
-                    value = "INVOKE",
-                    ordinal = 1,
-                    target = "Ljava/lang/Boolean;valueOf(Z)Ljava/lang/Boolean;"))
-    private void gravisuiteneo$setToAir(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side, float hitX,
-            float hitY, float hitZ, CallbackInfoReturnable<Boolean> cir) {
+            at = @At(value = "INVOKE", ordinal = 1, target = "Ljava/lang/Boolean;valueOf(Z)Ljava/lang/Boolean;"))
+    private void gravisuiteneo$setToAir(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side,
+            float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> cir) {
         world.setBlockToAir(x, y, z);
     }
 }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
@@ -11,7 +11,11 @@ import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -63,14 +67,14 @@ public class MixinItemVajra {
                     value = "INVOKE",
                     ordinal = 0,
                     target = "Lnet/minecraft/block/Block;onBlockHarvested(Lnet/minecraft/world/World;IIIILnet/minecraft/entity/player/EntityPlayer;)V"))
-    private void onBlockHarvestToNoOp(Block block, World world, int x, int y, int z, int meta, EntityPlayer player) {
+    private void gravisuiteneo$onBlockHarvestToNoOp(Block block, World world, int x, int y, int z, int meta, EntityPlayer player) {
         return;
     }
 
     @Redirect(
             method = "onItemUse",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(III)Z"))
-    private boolean setBlockToAirToNoOp(World world, int x, int y, int z) {
+    private boolean gravisuiteneo$setBlockToAirToNoOp(World world, int x, int y, int z) {
         return true;
     }
 
@@ -80,22 +84,22 @@ public class MixinItemVajra {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/block/Block;harvestBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIII)V"))
-    private void fixCallOrder(Block block, World world, EntityPlayer player, int x, int y, int z, int meta) {
+    private void gravisuiteneo$fixCallOrder(Block block, World world, EntityPlayer player, int x, int y, int z, int meta) {
         block.onBlockHarvested(world, x, y, z, meta, player);
         world.setBlockToAir(x, y, z);
         block.harvestBlock(world, player, x, y, z, meta);
     }
 
     // This one makes sure that if we're mining a block that canSilkHarvest it still gets set to air, since we yeeted
-    // the original setBlockToAir call above
+    // the original setBlockToAir call above. This injects at the end of the if(canSilkHarvest) block, at the assignment
+    // dropFlag = true
     @Inject(
             method = "onItemUse",
             at = @At(
                     value = "INVOKE",
-                    shift = At.Shift.AFTER,
                     ordinal = 1,
                     target = "Ljava/lang/Boolean;valueOf(Z)Ljava/lang/Boolean;"))
-    private void setToAir(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side, float hitX,
+    private void gravisuiteneo$setToAir(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side, float hitX,
             float hitY, float hitZ, CallbackInfoReturnable<Boolean> cir) {
         world.setBlockToAir(x, y, z);
     }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13562

Right now, the vajra has the following process for breaking blocks in accurate mode:

- harvestBlock
- onBlockHarvested
- setBlockToAir

However, most things in the game go in the order described here http://greyminecraftcoder.blogspot.com/2015/01/summary-of-logic-flow-when-mining-blocks.html

We have a small subset of blocks who have kind of a funky process where they drop themselves during onBlockHarvested, and make sure by the time harvestBlock is called that their getDrops returns nothing. The two best examples are any flowers from Botania and also Thaumcraft nodes in jars.

The current order of calls means that the vajra will dupe these items. These redirects change the order to match the standard flow.

I tested this and it works, no more dupes, but this is my first time writing a mixin, so please review carefully.