### PR TITLE
Fix Quantum Shield on Servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.50:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.104:dev')
     implementation('curse.maven:cofh-lib-220333:2388748')
     implementation(deobf('https://forum.industrial-craft.net/core/attachment/4519-gravisuite-1-7-10-2-0-3-jar'))
 }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/GraviSuiteNeoMixins.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/GraviSuiteNeoMixins.java
@@ -32,13 +32,13 @@ public class GraviSuiteNeoMixins implements ILateMixinLoader {
         mixins.add("MixinItemUltimateLappack");
         mixins.add("MixinItemVajra");
         mixins.add("MixinPacketHandler");
+        mixins.add("MixinKeyboard");
 
         if (FMLCommonHandler.instance().getSide().isClient()) {
             mixins.add("MixinClientProxy");
             mixins.add("MixinGuiHandler");
             mixins.add("MixinGuiRelocatorDisplay");
             mixins.add("MixinItemSimpleItems");
-            mixins.add("MixinKeyboard");
             mixins.add("MixinKeyboardClient");
             mixins.add("MixinRenderPlasmaBall");
         }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinKeyboard.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinKeyboard.java
@@ -1,10 +1,14 @@
 package com.gtnewhorizons.gravisuiteneo.mixins;
 
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -16,6 +20,32 @@ import gravisuite.keyboard.Keyboard;
 
 @Mixin(Keyboard.class)
 public class MixinKeyboard {
+
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> boostKeyState;
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> jumpKeyState;
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> sneakKeyState;
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> forwardKeyState;
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> altKeyState;
+    @Shadow(remap = false)
+    private static Map<EntityPlayer, Boolean> modeKeyState;
+
+    /**
+     * Replace HashMap with WeakHashMap to prevent leaking EntityPlayer (and contained World) Objects.
+     */
+    @Inject(method = "<clinit>", at = @At("TAIL"), remap = false)
+    private static void gravisuiteneo$clinit(CallbackInfo ci) {
+        boostKeyState = new WeakHashMap<>();
+        jumpKeyState = new WeakHashMap<>();
+        sneakKeyState = new WeakHashMap<>();
+        forwardKeyState = new WeakHashMap<>();
+        altKeyState = new WeakHashMap<>();
+        modeKeyState = new WeakHashMap<>();
+    }
 
     @Inject(
             at = @At(


### PR DESCRIPTION
Fixes Quantum Shield  (and other Keybinds) on Servers by actually enabling the common Mixin on Servers.
Fixes the activation part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13067

Also added a fix for an EntityPlayer memory leak.