### PR TITLE
Fix vajra voiding

### DIFF
--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
@@ -87,8 +87,10 @@ public class MixinItemVajra {
     private void gravisuiteneo$fixCallOrder(Block block, World world, EntityPlayer player, int x, int y, int z,
             int meta) {
         block.onBlockHarvested(world, x, y, z, meta, player);
-        world.setBlockToAir(x, y, z);
-        block.harvestBlock(world, player, x, y, z, meta);
+        if (block.removedByPlayer(world, player, x, y, z, true)) {
+            block.onBlockDestroyedByPlayer(world, x, y, z, meta);
+            block.harvestBlock(world, player, x, y, z, meta);
+        }
     }
 
     // This one makes sure that if we're mining a block that canSilkHarvest it still gets set to air, since we yeeted


### PR DESCRIPTION
Checked how a few other mods were doing it.
Calling `onBlockDestroyedByPlayer` isn't actually necessary, but there might be some mod block out there that needs it.

This correctly retains the inventory of super tanks/chests etc. and doesn't dupe botania flowers or tc jars.
I've tested with most things mentioned in the ticket and all seems fine.
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11746