### PR TITLE
Fix Vajra unintended behaviour

### DIFF
--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
 
@@ -71,13 +70,6 @@ public class MixinItemVajra {
         return;
     }
 
-    @Redirect(
-            method = "onItemUse",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(III)Z"))
-    private boolean gravisuiteneo$setBlockToAirToNoOp(World world, int x, int y, int z) {
-        return true;
-    }
-
     // harvestBlock would be called first by the vajra, so we redirect to the proper chain of calls
     @Redirect(
             method = "onItemUse",
@@ -91,16 +83,5 @@ public class MixinItemVajra {
             block.onBlockDestroyedByPlayer(world, x, y, z, meta);
             block.harvestBlock(world, player, x, y, z, meta);
         }
-    }
-
-    // This one makes sure that if we're mining a block that canSilkHarvest it still gets set to air, since we yeeted
-    // the original setBlockToAir call above. This injects at the end of the if(canSilkHarvest) block, at the assignment
-    // dropFlag = true
-    @Inject(
-            method = "onItemUse",
-            at = @At(value = "INVOKE", ordinal = 1, target = "Ljava/lang/Boolean;valueOf(Z)Ljava/lang/Boolean;"))
-    private void gravisuiteneo$setToAir(ItemStack is, EntityPlayer player, World world, int x, int y, int z, int side,
-            float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> cir) {
-        world.setBlockToAir(x, y, z);
     }
 }


### PR DESCRIPTION
Some blocks overwrite `block.removedByPlayer` without calling super or otherwise setting the block to air.
And instead of calling `world.setBlockToAir` at the end of both "branches" of the Vajra's onItemUse individually we go back to calling it where it originally did.

From my testing this seems to have the intended behaviour.
Super tank/chest, compressed chest etc. retains their inventory correctly.
Botania flowers, Thaumcraft jars, LT, etc. are correctly destroyed.

Closes: https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/121