### PR TITLE
Don't consume water (or other) cells to extinguish wearers of the Advanced NanoChestPlate

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.56:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.08:dev')
     implementation('curse.maven:cofh-lib-220333:2388748')
     implementation(deobf('https://forum.industrial-craft.net/core/attachment/4519-gravisuite-1-7-10-2-0-3-jar'))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -85,6 +85,11 @@ accessTransformersFile = gravisuiteneo_at.cfg
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
 
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
+
 # Adds some debug arguments like verbose output and class export.
 usesMixinDebug = true
 
@@ -117,8 +122,14 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/GraviSuiteNeoMixins.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/GraviSuiteNeoMixins.java
@@ -27,6 +27,7 @@ public class GraviSuiteNeoMixins implements ILateMixinLoader {
         mixins.add("MixinItemAdvancedLappack");
         mixins.add("MixinItemAdvChainsaw");
         mixins.add("MixinItemAdvDDrill");
+        mixins.add("MixinItemAdvancedNanoChestPlate");
         mixins.add("MixinItemGraviChestPlate");
         mixins.add("MixinItemRelocator");
         mixins.add("MixinItemUltimateLappack");

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
@@ -1,14 +1,38 @@
 package com.gtnewhorizons.gravisuiteneo.mixins;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
 
+import gravisuite.ItemAdvancedJetPack;
 import gravisuite.ItemAdvancedNanoChestPlate;
+import ic2.api.item.ElectricItem;
 
 @Mixin(ItemAdvancedNanoChestPlate.class)
-public class MixinItemAdvancedNanoChestPlate {
+public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack {
+
+    @Shadow
+    private static byte tickRate = 20;
+    @Shadow
+    private static byte ticker;
+    @Shadow
+    private int energyForExtinguish = 50000;
+
+    /**
+     * Ignore me, required to enable super calls.
+     */
+    public MixinItemAdvancedNanoChestPlate(ArmorMaterial armorMaterial, int par3, int par4) {
+        super(armorMaterial, par3, par4);
+    }
 
     /**
      * @author Namikon, glowredman
@@ -26,5 +50,25 @@ public class MixinItemAdvancedNanoChestPlate {
     @Overwrite(remap = false)
     private double getBaseAbsorptionRatio() {
         return 1.0;
+    }
+
+    /**
+     * @author YannickMG, Caedis
+     * @reason The original method mistakenly consumed the wrong types of cells, and consuming water cells felt
+     *         unnecessary. <br>
+     *         Motivated by <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15529">Issue
+     *         #15529</a>.
+     */
+    @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
+    void onArmorTickLenient(World worldObj, EntityPlayer player, ItemStack itemStack, CallbackInfo ci) {
+        super.onArmorTick(worldObj, player, itemStack);
+        byte currentTick = ticker;
+        ticker = (byte) (currentTick + 1);
+        if (currentTick % tickRate == 0 && player.isBurning()
+                && ElectricItem.manager.canUse(itemStack, energyForExtinguish)) {
+            ItemAdvancedNanoChestPlate.use(itemStack, energyForExtinguish);
+            player.extinguish();
+        }
+        ci.cancel();
     }
 }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
@@ -17,7 +17,7 @@ import gravisuite.ItemAdvancedJetPack;
 import gravisuite.ItemAdvancedNanoChestPlate;
 import ic2.api.item.ElectricItem;
 
-@Mixin(ItemAdvancedNanoChestPlate.class)
+@Mixin(value = ItemAdvancedNanoChestPlate.class, remap = false)
 public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack {
 
     @Shadow
@@ -38,7 +38,7 @@ public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack {
      * @author Namikon, glowredman
      * @reason Gravitation Suite Neo
      */
-    @Overwrite(remap = false)
+    @Overwrite
     public double getDamageAbsorptionRatio() {
         return Properties.ArmorPresets.AdvNanoChestPlate.absorptionRatio;
     }
@@ -47,7 +47,7 @@ public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack {
      * @author Namikon, glowredman
      * @reason Gravitation Suite Neo
      */
-    @Overwrite(remap = false)
+    @Overwrite
     private double getBaseAbsorptionRatio() {
         return 1.0;
     }
@@ -59,7 +59,7 @@ public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack {
      *         Motivated by <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15529">Issue
      *         #15529</a>.
      */
-    @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true)
     void onArmorTickLenient(World worldObj, EntityPlayer player, ItemStack itemStack, CallbackInfo ci) {
         super.onArmorTick(worldObj, player, itemStack);
         byte currentTick = ticker;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15529 by sidestepping the problem and not requiring the consumption of cells.

In the context of the pack, it doesn't make much sense to require carrying around a stack of water cells just to benefit from your suit's fire protection capabilities.

Also actually enable the previous mixins written for this item, which hadn't previously been enabled.

Thanks to @Caedis for guiding me through my first Mixin.