### PR TITLE
Disabled fire extinguishing for Advanced NanoChestPlate and GraviChestPlate if fire resistance is active

### DIFF
--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedNanoChestPlate.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.gravisuiteneo.mixins;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
 import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -69,6 +70,7 @@ public class MixinItemAdvancedNanoChestPlate extends ItemAdvancedJetPack impleme
         byte currentTick = ticker;
         ticker = (byte) (currentTick + 1);
         if (currentTick % tickRate == 0 && player.isBurning()
+                && !player.isPotionActive(Potion.fireResistance)
                 && ElectricItem.manager.canUse(itemStack, energyForExtinguish)) {
             ItemAdvancedJetPack.use(itemStack, energyForExtinguish);
             player.extinguish();

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviChestPlate.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviChestPlate.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
@@ -74,7 +75,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             remap = false)
     private boolean gravisuiteneo$checkCanExtinguish(boolean original, World worldObj, EntityPlayer player,
             ItemStack itemStack) {
-        if (original && ElectricItem.manager.canUse(itemStack, QuantumShieldHelper.DISCHARGE_EXTINGUISH)) {
+        if (original && ElectricItem.manager.canUse(itemStack, QuantumShieldHelper.DISCHARGE_EXTINGUISH)
+                && !player.isPotionActive(Potion.fireResistance)) {
             ElectricItem.manager.discharge(itemStack, QuantumShieldHelper.DISCHARGE_EXTINGUISH, 4, true, false, false);
             return true;
         }


### PR DESCRIPTION
This PR disables the extinguishing feature of Advanced NanoChestPlate and GraviChestPlate's if the player currently has the fire resistance potion effect active. In GTNH, the most common way of having fire resistance is from pigman backpack, and it should be compatible with the pigman backpack since it displays as giving fire resistance effect with pigman backpack when I play GTNH. 

There shouldn't really be a downside to this because if your fire resistance runs out while still being on fire, then it will extinguish before you actually start taking damage.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22914. 