### PR TITLE
Send GraviSuite item and armor status messages server-side only

### DIFF
--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/common/EventHandler.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/common/EventHandler.java
@@ -15,6 +15,7 @@ import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import com.gtnewhorizons.gravisuiteneo.GraviSuiteNeo;
 import com.gtnewhorizons.gravisuiteneo.GraviSuiteNeoRegistry;
 import com.gtnewhorizons.gravisuiteneo.common.DamageSources.EntityDamageSourcePlazma;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.gtnewhorizons.gravisuiteneo.util.QuantumShieldHelper;
 
 import cpw.mods.fml.common.eventhandler.EventPriority;
@@ -99,7 +100,8 @@ public class EventHandler {
         if (!QuantumShieldHelper.hasValidShieldEquipment(player)) {
             // Shield mode is enabled, but player has the wrong armor items
             QuantumShieldHelper.saveShieldMode(chest, false);
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.invalidSetupShieldBreak")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             QuantumShieldHelper.notifyWorldShieldDown(player);
@@ -109,7 +111,8 @@ public class EventHandler {
         if (!ElectricItem.manager.canUse(chest, energyRequired)) {
             // Not enough energy to absorb damage. Shield "breaks"
             QuantumShieldHelper.saveShieldMode(chest, false);
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.lowpowerShieldBreak")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             QuantumShieldHelper.notifyWorldShieldDown(player);

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/items/ItemPlasmaLauncher.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/items/ItemPlasmaLauncher.java
@@ -20,6 +20,7 @@ import com.gtnewhorizons.gravisuiteneo.client.ICustomItemBars;
 import com.gtnewhorizons.gravisuiteneo.common.EntityPlasmaBallMKII;
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
 import com.gtnewhorizons.gravisuiteneo.inventory.InventoryItem;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 
 import gravisuite.EntityPlasmaBall;
 import gravisuite.GraviSuite;
@@ -61,7 +62,8 @@ public class ItemPlasmaLauncher extends Item implements ICustomItemBars {
         ItemStack ammoStack = this.getAmmunition(itemStackIn);
 
         if (ammoStack == null) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.plasmaLauncher.noPlasmaCellFound")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             return itemStackIn;
@@ -69,13 +71,15 @@ public class ItemPlasmaLauncher extends Item implements ICustomItemBars {
 
         FluidStack plasma = ((ItemPlasmaCell) GraviSuiteNeoRegistry.itemPlasmaCell).getFluid(ammoStack);
         if (plasma == null) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.plasmaLauncher.PlasmaCellEmpty")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             return itemStackIn;
         }
         if (plasma.amount < PLASMA_AMOUNT_PER_SHOT) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.plasmaLauncher.NotEnoughPlasma")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             return itemStackIn;
@@ -97,7 +101,8 @@ public class ItemPlasmaLauncher extends Item implements ICustomItemBars {
             }
             player.swingItem();
         } else {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.plasmaLauncher.noEnergy")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
         }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvChainsaw.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvChainsaw.java
@@ -30,6 +30,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.gtnewhorizons.gravisuiteneo.GraviSuiteNeo;
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -160,7 +161,8 @@ public abstract class MixinItemAdvChainsaw extends ItemTool {
                 modeMsg = new ChatComponentTranslation("message.advChainsaw.mode.treecapitator")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.AQUA));
             }
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.text.mode")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(": ")
                             .appendSibling(modeMsg));

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvDDrill.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvDDrill.java
@@ -37,6 +37,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import com.gtnewhorizons.gravisuiteneo.common.Achievements;
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.gtnewhorizons.gravisuiteneo.util.LevelableToolHelper;
 
 import cpw.mods.fml.relauncher.Side;
@@ -184,7 +185,8 @@ public abstract class MixinItemAdvDDrill extends ItemTool {
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN));
                 break;
         }
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.mode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(": ")
                         .appendSibling(modeMsg));
@@ -407,7 +409,8 @@ public abstract class MixinItemAdvDDrill extends ItemTool {
             }
 
             if (lowPower) {
-                player.addChatMessage(
+                ChatUtil.sendToPlayer(
+                        player,
                         new ChatComponentTranslation("message.advDDrill.noEnergy")
                                 .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
                 return false;

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedJetPack.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedJetPack.java
@@ -13,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 
@@ -55,7 +56,8 @@ public class MixinItemAdvancedJetPack {
             method = "switchFlyState",
             remap = false)
     private static void gravisuiteneo$translateJetpackEngineDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.advElJetpack.jetpackEngine")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -70,7 +72,8 @@ public class MixinItemAdvancedJetPack {
             method = "switchFlyState",
             remap = false)
     private static void gravisuiteneo$translateJetpackEngineEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.advElJetpack.jetpackEngine")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));
@@ -87,7 +90,8 @@ public class MixinItemAdvancedJetPack {
             method = "switchWorkMode",
             remap = false)
     private static void gravisuiteneo$translateHoverModeDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.advElJetpack.hoverMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -102,7 +106,8 @@ public class MixinItemAdvancedJetPack {
             method = "switchWorkMode",
             remap = false)
     private static void gravisuiteneo$translateHoverModeEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.advElJetpack.hoverMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedLappack.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemAdvancedLappack.java
@@ -20,6 +20,7 @@ import com.gtnewhorizons.gravisuiteneo.common.Achievements;
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
 import com.gtnewhorizons.gravisuiteneo.items.IItemCharger;
 import com.gtnewhorizons.gravisuiteneo.items.ItemEpicLappack;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 
 import cofh.api.energy.IEnergyContainerItem;
 import gravisuite.GraviSuite;
@@ -64,7 +65,8 @@ public class MixinItemAdvancedLappack implements IItemCharger {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translatePowerSupplyDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.powerSupply")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -78,7 +80,8 @@ public class MixinItemAdvancedLappack implements IItemCharger {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translatePowerSupplyEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.powerSupply")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviChestPlate.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviChestPlate.java
@@ -20,6 +20,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.gtnewhorizons.gravisuiteneo.util.QuantumShieldHelper;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
@@ -45,7 +46,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
         if (!QuantumShieldHelper.readShieldMode(itemStack)) return;
 
         if (!QuantumShieldHelper.hasValidShieldEquipment(player)) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.invalidSetupShieldBreak")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             QuantumShieldHelper.saveShieldMode(itemStack, false);
@@ -56,7 +58,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
 
         if (!player.capabilities.isCreativeMode) {
             if (ItemGraviChestPlate.getCharge(itemStack) < QuantumShieldHelper.DISCHARGE_IDLE) {
-                player.addChatMessage(
+                ChatUtil.sendToPlayer(
+                        player,
                         new ChatComponentTranslation("message.graviChestPlate.lowpowerShieldBreak")
                                 .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
                 QuantumShieldHelper.saveShieldMode(itemStack, false);
@@ -142,7 +145,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "switchFlyState",
             remap = false)
     private static void gravisuiteneo$translateGravityEngineDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.gravitationEngine")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -157,7 +161,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "switchFlyState",
             remap = false)
     private static void gravisuiteneo$translateGravityEngineLowEnergy(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.lowEnergy")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -171,7 +176,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "switchFlyState",
             remap = false)
     private static void gravisuiteneo$translateGravityEngineEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.gravitationEngine")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));
@@ -188,7 +194,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "switchWorkMode",
             remap = false)
     private static void gravisuiteneo$translateLevitationModeDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.levitationMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -203,7 +210,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "switchWorkMode",
             remap = false)
     private static void gravisuiteneo$translateLevitationModeEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.levitationMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));
@@ -233,7 +241,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "onArmorTick",
             remap = false)
     private void gravisuiteneo$translateShutdownMessage(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.shutdown")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -247,7 +256,8 @@ public class MixinItemGraviChestPlate implements IHazardProtector {
             method = "onArmorTick",
             remap = false)
     private void gravisuiteneo$translateNoEnergyToBoostMessage(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.graviChestPlate.noEnergyToBoost")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviTool.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemGraviTool.java
@@ -9,6 +9,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
+
 import gravisuite.ItemGraviTool;
 
 @Mixin(ItemGraviTool.class)
@@ -23,7 +25,8 @@ public class MixinItemGraviTool {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateHoeActivated(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("graviTool.snap.Hoe")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.DARK_GREEN)).appendText(" ")
                         .appendSibling(
@@ -39,7 +42,8 @@ public class MixinItemGraviTool {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateTreeTapActivated(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("graviTool.snap.TreeTap")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GOLD)).appendText(" ").appendSibling(
                                 new ChatComponentTranslation("message.text.activated")
@@ -54,7 +58,8 @@ public class MixinItemGraviTool {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateWrenchActivated(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("graviTool.snap.Wrench")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.AQUA)).appendText(" ").appendSibling(
                                 new ChatComponentTranslation("message.text.activated")
@@ -69,7 +74,8 @@ public class MixinItemGraviTool {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateScrewdriverActivated(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("graviTool.snap.Screwdriver")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.LIGHT_PURPLE)).appendText(" ")
                         .appendSibling(
@@ -96,7 +102,8 @@ public class MixinItemGraviTool {
             method = { "onHoeUse", "onWrenchUse", "attemptExtract", "onScrewdriverUse", "canWrench" },
             remap = false)
     private void gravisuiteneo$translateNoEnergy(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.noenergy")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemRelocator.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemRelocator.java
@@ -22,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import com.gtnewhorizons.gravisuiteneo.common.EntityPlasmaBallMKII;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.llamalad7.mixinextras.sugar.Local;
 
 import gravisuite.EntityPlasmaBall;
@@ -71,7 +72,8 @@ public class MixinItemRelocator {
             remap = false)
     private void gravisuiteneo$sendTeleportingNowMessage(EntityPlayer player, ItemStack itemStack, String tpName,
             CallbackInfo ci, TeleportPoint point) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.teleportingnow")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GOLD)).appendText(" ").appendSibling(
                                 new ChatComponentText(point.pointName)
@@ -88,7 +90,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateModePersonal(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.mode").appendText(": ")
                         .appendSibling(new ChatComponentTranslation("message.relocator.mode.personal")));
     }
@@ -101,7 +104,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateModeTranslocator(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.mode").appendText(": ")
                         .appendSibling(new ChatComponentTranslation("message.relocator.mode.translocator")));
     }
@@ -114,7 +118,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateModePortal(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.mode").appendText(": ")
                         .appendSibling(new ChatComponentTranslation("message.relocator.mode.portal")));
     }
@@ -127,7 +132,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateTranslocatorDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.modeTranslocatorDisabled")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -140,7 +146,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translatePortalDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.modePortalDisabled")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -153,7 +160,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateRelocatorNoEnergy(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.noenergy")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -166,7 +174,8 @@ public class MixinItemRelocator {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateNoDefaultPoint(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.noDefaultPoint")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -194,7 +203,8 @@ public class MixinItemRelocator {
             remap = false)
     private static void gravisuiteneo$translatePointExists(EntityPlayer player, String ignored,
             @Local(argsOnly = true) TeleportPoint tp) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentText(tp.pointName).setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED))
                         .appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.relocator.text.pointExists")));
@@ -210,7 +220,8 @@ public class MixinItemRelocator {
             remap = false)
     private static void gravisuiteneo$translatePointAdded(EntityPlayer player, String ignored,
             @Local(argsOnly = true) TeleportPoint tp) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentText(tp.pointName).setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN))
                         .appendText(" ")
                         .appendSibling(new ChatComponentTranslation("message.relocator.text.poindAdded")));
@@ -239,7 +250,8 @@ public class MixinItemRelocator {
             remap = false)
     private static void gravisuiteneo$translateDefaultPointSet(EntityPlayer player, String ignored,
             @Local(argsOnly = true) String pointName) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.defaultPointSet")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(" ").appendSibling(
                                 new ChatComponentText(pointName)
@@ -255,7 +267,8 @@ public class MixinItemRelocator {
             method = "setDefaultPoint",
             remap = false)
     private static void gravisuiteneo$translatePointNotFound(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.relocator.text.noPoint")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }
@@ -280,7 +293,8 @@ public class MixinItemRelocator {
             method = "teleportPlayer",
             remap = false)
     private void gravisuiteneo$translateTeleportNoEnergy(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.text.noenergy")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/mixins/MixinItemVajra.java
@@ -21,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizons.gravisuiteneo.common.Properties;
+import com.gtnewhorizons.gravisuiteneo.util.ChatUtil;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 
@@ -41,7 +42,8 @@ public class MixinItemVajra {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateSilkTouchModeDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.vajra.silkTouchMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)).appendText(": ")
                         .appendSibling(new ChatComponentTranslation("message.text.disabled")));
@@ -55,7 +57,8 @@ public class MixinItemVajra {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateSilkTouchModeEnabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.vajra.silkTouchMode")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)).appendText(": ")
                         .appendSibling(new ChatComponentTranslation("message.text.enabled")));
@@ -69,7 +72,8 @@ public class MixinItemVajra {
                     value = "INVOKE"),
             method = "onItemRightClick")
     private void gravisuiteneo$translateSilkTouchDisabled(EntityPlayer player, String ignored) {
-        player.addChatMessage(
+        ChatUtil.sendToPlayer(
+                player,
                 new ChatComponentTranslation("message.vajra.silkTouchDisabled")
                         .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
     }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/util/ChatUtil.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/util/ChatUtil.java
@@ -1,0 +1,21 @@
+package com.gtnewhorizons.gravisuiteneo.util;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.IChatComponent;
+
+public final class ChatUtil {
+
+    private ChatUtil() {}
+
+    /**
+     * Send a chat message to the player from the logical server only, restoring GraviSuite's original
+     * ServerProxy.sendPlayerMessage behavior. Item and armor code such as onArmorTick and onItemRightClick runs on both
+     * sides, so emitting the message directly would duplicate it and, while the client-side energy value is desynced,
+     * print false low-power warnings. The component is still localized on the receiving client.
+     */
+    public static void sendToPlayer(EntityPlayer player, IChatComponent message) {
+        if (!player.worldObj.isRemote) {
+            player.addChatMessage(message);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/util/LevelableToolHelper.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/util/LevelableToolHelper.java
@@ -23,7 +23,8 @@ public class LevelableToolHelper {
 
         int nextLevel = getLevel(currentXP);
         if (nextLevel > currLevel) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.xp.levelup")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GOLD)));
         }

--- a/src/main/java/com/gtnewhorizons/gravisuiteneo/util/QuantumShieldHelper.java
+++ b/src/main/java/com/gtnewhorizons/gravisuiteneo/util/QuantumShieldHelper.java
@@ -79,14 +79,16 @@ public class QuantumShieldHelper {
      */
     public static void switchShieldMode(EntityPlayer player, ItemStack itemstack) {
         if (!hasValidShieldEquipment(player)) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.invalidshieldSetup")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             return;
         }
 
         if (!ElectricItem.manager.canUse(itemstack, DISCHARGE_IDLE * 10)) {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.ShieldUpNotEnoughPower")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             return;
@@ -94,7 +96,8 @@ public class QuantumShieldHelper {
 
         if (readShieldMode(itemstack)) {
             saveShieldMode(itemstack, false);
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.shieldMode")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.YELLOW)).appendText(" ")
                             .appendSibling(
@@ -103,7 +106,8 @@ public class QuantumShieldHelper {
             notifyWorldShieldDown(player);
         } else {
             saveShieldMode(itemstack, true);
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.shieldMode")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.YELLOW)).appendText(" ")
                             .appendSibling(
@@ -184,16 +188,19 @@ public class QuantumShieldHelper {
                 curePotions(itemstack, player, true);
                 // TODO: add medkit sound player.worldObj.playSoundAtEntity(player, GraviSuiteNeo.MODID + ":medkit",
                 // 1.25F, 1.0F);
-                player.addChatMessage(
+                ChatUtil.sendToPlayer(
+                        player,
                         new ChatComponentTranslation("message.graviChestPlate.MedkitInjected")
                                 .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)));
             } else {
-                player.addChatMessage(
+                ChatUtil.sendToPlayer(
+                        player,
                         new ChatComponentTranslation("message.graviChestPlate.MedkitNoNanoBots")
                                 .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
             }
         } else {
-            player.addChatMessage(
+            ChatUtil.sendToPlayer(
+                    player,
                     new ChatComponentTranslation("message.graviChestPlate.MedkitNoPower")
                             .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
         }


### PR DESCRIPTION
GraviSuite emits armor and tool status messages from code that runs on both sides. Since PR #32 these go through an unconditional addChatMessage instead of the old server-only ServerProxy call, so the client re-emits them from its desynced state: false low-energy spam on the armor and doubled mode lines on the tools. Route them through a single server-side ChatUtil.sendToPlayer, keeping the messages localized on the receiving client.